### PR TITLE
Adding basic support for the Tinkergraph in-memory graph database engine 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ And finally run Celery::
 You can also run it in daemon mode by passing the argument `multi`::
 
   $ celery multi start w1 w2 -A sylva.celery -l info
-  
+
 Reports
 -------
 Sylva now supports generation of reports based on queries plot into charts. To enable, just add::
@@ -149,8 +149,99 @@ When in daemon mode, be sure to only run the beat once, otherwise you'll have du
 
   $ celery multi start w1 --beat -A sylva.celery -l info
   $ celery multi start w2 -A sylva.celery -l info
-  
 
+Support for the Tinkerpop3 Graph (Experimental)
+-----------------------------------------------
+
+The SylvaDB community is in the process of adding support for `Tinkerpop3`_ enabled
+graph databases that use the Gremlin Server for communication.
+
+Currently, SylvaDB includes optional experimental support for the `Tinkergraph`_
+in-memory graph database. This database is not meant to be a production, or even
+local, data store for regular SylvaDB use. Instead it is intended to be a first
+step towards adding support for persistent graph databases such as `Titan`_.
+
+If you would like to try out the Tinkergraph implementation, please follow the
+steps provided in this README regarding installing SylvaDB requirements and
+the relational database until you arrive at the section titled "Graph Database".
+Then continue as follows:
+
+First install gremlinrestclient, the client used to connect to the Gremlin Server::
+
+    $ pip install gremlinrestclient
+
+Next download and unpack the 3.0.0.M9 Gremlin Server::
+
+    $ cd git/Sylva
+    $ wget https://dist.apache.org/repos/dist/release/incubator/tinkerpop/3.0.0.M9-incubating/apache-gremlin-server-3.0.0.M9-incubating-bin.zip
+    $ unzip apache-gremlin-server-3.0.0.M9-incubating-bin.zip
+    $ mv apache-gremlin-server-3.0.0.M9-incubating gremlin
+
+Then you will have to update the config a bit. Create a file called `sylva.groovy`
+in the directory `gremlin/scripts/` and add the following::
+
+    g = graph.traversal()
+
+Next create a file `sylva.yaml` in the directory `gremlin/conf/` and add the following::
+
+    host: localhost
+    port: 8182
+    threadPoolWorker: 1
+    gremlinPool: 8
+    scriptEvaluationTimeout: 30000
+    serializedResponseTimeout: 30000
+    channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
+    graphs: {
+      graph: conf/tinkergraph-empty.properties}
+    plugins:
+      - tinkerpop.tinkergraph
+    scriptEngines: {
+      gremlin-groovy: {
+        imports: [java.lang.Math],
+        staticImports: [java.lang.Math.PI],
+        scripts: [scripts/sylva.groovy]}}
+    serializers:
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }  # application/vnd.gremlin-v1.0+json
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }         # application/json
+    metrics: {
+      slf4jReporter: {enabled: true, interval: 180000}}
+    threadPoolBoss: 1
+    maxInitialLineLength: 4096
+    maxHeaderSize: 8192
+    maxChunkSize: 8192
+    maxContentLength: 65536
+    maxAccumulationBufferComponents: 1024
+    resultIterationBatchSize: 64
+
+Finally, we need to configure SylvaDB to run the proper backend. In the
+whatever settings file you use to run SylvaDB, you can simply change the
+GRAPHDATABASES default graph settings to the following::
+
+    'default': {
+        'ENGINE': 'engines.gdb.backends.tinkergraph',
+        'NAME': '',  # Changed to avoid overwrites from testing
+        'USER': '',
+        'PASSWORD': '',
+        'SCHEMA': 'http',
+        'HOST': 'localhost',
+        'PORT': '8182',  # Changed to avoid overwrites from testing
+    }
+
+As Tinkergraph is does not have text search enabled lookups, it does not run
+against the SylvaDB test suite, nor does it support the `reports` or `queries`
+applications. Furthermore, it does not support data dumps or OLAP, so there is no
+current analytics functionality. This will all be added with support for Titan.
+Please disable these applications in your settings::
+
+    ENABLE_QUERIES = False
+    ENABLE_REPORTS = False
+    ENABLE_REPORTS_PDF = False
+    ENABLE_ANALYTICS = False
+
+Finally, run SylvaDB's dev server as per usual
+(with whatever settings you configured for TP3) and fire up the Gremlin Server::
+
+    % ./gremlin/bin/gremlin-server.sh conf/sylva.yaml
 
 
 .. _Sylva: http://www.sylvadb.com
@@ -164,3 +255,6 @@ When in daemon mode, be sure to only run the beat once, otherwise you'll have du
 .. _pip: http://pypi.python.org/pypi/pip
 .. _virtualenv: http://pypi.python.org/pypi/virtualenv
 .. _virtualenvwrapper: http://www.doughellmann.com/docs/virtualenvwrapper/
+.. _tinkerpop3: http://tinkerpop.incubator.apache.org/
+.. _tinkergraph: http://tinkerpop.incubator.apache.org/docs/3.0.0.M9-incubating/#tinkergraph-gremlin
+.. _titan: http://s3.thinkaurelius.com/docs/titan/0.9.0-M2/

--- a/README.rst
+++ b/README.rst
@@ -150,8 +150,8 @@ When in daemon mode, be sure to only run the beat once, otherwise you'll have du
   $ celery multi start w1 --beat -A sylva.celery -l info
   $ celery multi start w2 -A sylva.celery -l info
 
-Support for the Tinkerpop3 Graph (Experimental)
------------------------------------------------
+Support for Tinkerpop3/Gremlin Server (Experimental)
+----------------------------------------------------
 
 The SylvaDB community is in the process of adding support for `Tinkerpop3`_ enabled
 graph databases that use the Gremlin Server for communication.
@@ -219,12 +219,12 @@ GRAPHDATABASES default graph settings to the following::
 
     'default': {
         'ENGINE': 'engines.gdb.backends.tinkergraph',
-        'NAME': '',  # Changed to avoid overwrites from testing
+        'NAME': '',
         'USER': '',
         'PASSWORD': '',
         'SCHEMA': 'http',
         'HOST': 'localhost',
-        'PORT': '8182',  # Changed to avoid overwrites from testing
+        'PORT': '8182',
     }
 
 As Tinkergraph is does not have text search enabled lookups, it does not run
@@ -241,7 +241,7 @@ Please disable these applications in your settings::
 Finally, run SylvaDB's dev server as per usual
 (with whatever settings you configured for TP3) and fire up the Gremlin Server::
 
-    % ./gremlin/bin/gremlin-server.sh conf/sylva.yaml
+    $ ./gremlin/bin/gremlin-server.sh conf/sylva.yaml
 
 
 .. _Sylva: http://www.sylvadb.com

--- a/sylva/engines/gdb/backends/tinkergraph.py
+++ b/sylva/engines/gdb/backends/tinkergraph.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+from requests.exceptions import ConnectionError
+from gremlinrestclient import PyBlueprintsGraphDatabase
+from engines.gdb.backends import (GraphDatabaseInitializationError,
+                                  GraphDatabaseConnectionError)
+from engines.gdb.backends.blueprints import BlueprintsGraphDatabase
+from engines.gdb.lookups.tinkergraph import Q as q_lookup_builder
+
+
+class GraphDatabase(BlueprintsGraphDatabase):
+
+    def __init__(self, url, params=None, graph=None):
+        self.url = url
+        self.params = params or {}
+        self.graph = graph
+        if not self.graph:
+            raise GraphDatabaseInitializationError("graph parameter required")
+        self.graph_id = str(self.graph.id)
+        try:
+            self.gdb = PyBlueprintsGraphDatabase(self.url)
+            self.setup_indexes()
+        except ConnectionError:
+            raise GraphDatabaseConnectionError(self.url)
+
+    def analysis(self):
+        # Maybe this should be added to base...
+        return None
+
+    def setup_indexes(self):
+        script = """graph.createIndex('_label', Vertex.class);
+                    graph.createIndex('_id', Vertex.class);
+                    graph.createIndex('_label', Edge.class);
+                    graph.createIndex('_id', Edge.class);"""
+        self.gdb.execute(script)
+
+    def _delete_element_property(self, element, key, element_type=None):
+        self._validate_property(key)
+        self._check_property(element, key)
+        element.removeProperty(key)
+
+    def _set_element_properties(self, element, properties, element_type=None):
+        for key in properties:
+            self._validate_property(key)
+        for key in self._get_public_keys(element):
+            element.removeProperty(key)
+        for key, value in properties.iteritems():
+            element.setProperty(key, value)
+
+    def _delete_element_properties(self, element, element_type=None):
+        for key in self._get_public_keys(element):
+            element.removeProperty(key)
+
+    def create_node(self, label, properties=None):
+        # Label must be a string
+        if not label or not isinstance(label, basestring):
+            raise TypeError("label must be a string")
+        vertex = self.gdb.addVertex()
+        if type(properties) == dict:
+            # Properties starting with _ are not allowed
+            for key in properties.keys():
+                self._validate_property(key)
+            for key, value in properties.iteritems():
+                vertex.setProperty(key, value)
+        # _id and _label is a mandatory internal properties
+        if "_id" not in vertex.getPropertyKeys():
+            vertex.setProperty("_id", vertex.getId())
+        vertex.setProperty("%slabel" % self.PRIVATE_PREFIX, label)
+        vertex.setProperty("%sgraph" % self.PRIVATE_PREFIX, self.graph_id)
+        return vertex.getId()
+
+    def get_all_nodes(self, include_properties=False):
+        return self.get_filtered_nodes({"graph": unicode(self.graph_id)},
+                                       include_properties=include_properties)
+
+    def get_nodes_by_label(self, label, include_properties=False, **kwargs):
+        return self.get_filtered_nodes({}, label=label,
+                                       include_properties=include_properties)
+
+    def create_relationship(self, id1, id2, label, properties=None):
+        # Label must be a string
+        if not label or not isinstance(label, basestring):
+            raise TypeError("label must be a string")
+        v1 = self._get_vertex(id1)
+        v2 = self._get_vertex(id2)
+        edge = self.gdb.addEdge(v1, v2, label)
+        if type(properties) == dict:
+            # Properties starting with _ are not allowed
+            for key in properties.keys():
+                self._validate_property(key)
+            for key, value in properties.iteritems():
+                edge.setProperty(key, value)
+        # _id and _label is a mandatory internal property
+        if "_id" not in edge.getPropertyKeys():
+            edge.setProperty("_id", edge.getId())
+        edge.setProperty("%slabel" % self.PRIVATE_PREFIX, label)
+        edge.setProperty("%sgraph" % self.PRIVATE_PREFIX, self.graph_id)
+        return edge.getId()
+
+    def get_all_relationships(self, include_properties=False):
+        return self.get_filtered_relationships(
+            {"_graph": unicode(self.graph_id)},
+            include_properties=include_properties)
+
+    def get_relationships_by_label(self, label, include_properties=False):
+        return self.get_filtered_relationships(
+            {}, label=label,
+            include_properties=include_properties)
+
+    def get_filtered_nodes(self, lookups, label=None, include_properties=None,
+                           limit=None, offset=None, order_by=None):
+        """
+        Get an iterator for filtered nodes using the parameters expressed in
+        the dictionary lookups.
+        The most usual lookups from Django should be implemented.
+        """
+        if label is not None:
+            labels = self._prep_labels(label)
+            script = "g.V().or(%s)" % labels
+        else:
+            script = "g.V()"
+        bindings = {}
+        if lookups:
+            where, bindings = self._prep_lookups(lookups)
+            script = "%s.and(%s)" % (script, where)
+        resp = self.gdb.execute(script, bindings=bindings)
+        if include_properties:
+            for v in resp.data:
+                props = {k: v[0]["value"] for k, v in v["properties"].items()}
+                yield (v["id"], props, v["properties"]["_label"][0]["value"])
+        else:
+            for v in resp.data:
+                yield (v["id"], None, None)
+
+    def get_filtered_relationships(self, lookups, label=None,
+                                   include_properties=None, limit=None,
+                                   offset=None, order_by=None):
+        """
+        Get an iterator for filtered relationship using the parameters
+        expressed in the dictionary lookups.
+        The most usual lookups from Django should be implemented.
+        """
+        if label is not None:
+            labels = self._prep_labels(label)
+            script = "g.E().or(%s)" % labels
+        else:
+            script = "g.E()"
+        bindings = {}
+        if lookups:
+            where, bindings = self._prep_lookups(lookups)
+            script = "%s.and(%s)" % (script, where)
+        resp = self.gdb.execute(script, bindings=bindings)
+        if include_properties:
+            for e in resp.data:
+                props = e["properties"]
+                # Node class in graph/mixins will do this if not here.
+                out_v = self.gdb.execute(
+                    "g.V(vid)", bindings={"vid": e["outV"]})
+                in_v = self.gdb.execute(
+                    "g.V(vid)", bindings={"vid": e["inV"]})
+                out_v = out_v.data[0]
+                in_v = in_v.data[0]
+                source = {
+                    "id": out_v["id"],
+                    "properties": out_v["properties"],
+                    "label": out_v["properties"]["_label"]}
+                target = {
+                    "id": in_v["id"],
+                    "properties": in_v["properties"],
+                    "label": in_v["properties"]["_label"]}
+                yield (
+                    e["id"], props, e["properties"]["_label"], source, target)
+        else:
+            for e in resp.data:
+                yield (e["id"], None, None)
+
+    def _prep_labels(self, label):
+        has = "has('%s', '%s')"
+        labels = []
+        if isinstance(label, (list, tuple)):
+            label = [has % ('_label', unicode(l)) for l in label
+                     if bool(l)]
+            labels += label
+        elif label:
+            label = has % ('_label', unicode(label))
+            labels.append(label)
+        return ','.join(labels)
+
+    def _prep_lookups(self, lookups):
+        wheres = q_lookup_builder()
+        for lookup in lookups:
+            if isinstance(lookup, q_lookup_builder):
+                wheres &= lookup
+            elif isinstance(lookup, dict):
+                wheres &= q_lookup_builder(**lookup)
+        where, bindings = wheres.get_query_objects()
+        return where, bindings
+
+    def lookup_builder(self):
+        # Should be added to base.
+        return q_lookup_builder
+
+    def get_nodes_count(self, label=None):
+        """
+        Get the number of total nodes.
+        If "label" is provided, the number is calculated according the
+        the label of the element.
+        """
+        if label is not None:
+            labels = self._prep_labels(label)
+            script = "g.V().or(%s).count()" % labels
+            print("SFsadfasdfsdfsad", script)
+        else:
+            script = """g.V().count()"""
+        resp = self.gdb.execute(script)
+        count = resp.data[0]
+        return count
+
+    def get_node_relationships_count(self, id, incoming=False, outgoing=False,
+                                     label=None):
+        """
+        Get the number of all relationships of a node.
+        If "incoming" is True, it only counts the ids for incoming ones.
+        If "outgoing" is True, it only counts the ids for outgoing ones.
+        If "label" is provided, relationships will be filtered.
+        """
+        bindings = {"vid": id}
+        if label is not None:
+            labels = self._prep_labels(label)
+            label_script = ".or(%s)" % labels
+        else:
+            label_script = ""
+        if incoming and not outgoing:
+            script = "g.V(vid).inE()%s.count()" % label_script
+        elif outgoing and not incoming:
+            script = "g.V(vid).outE()%s.count()" % label_script
+        else:
+            script = "g.V(vid).bothE()%s.count()" % label_script
+        resp = self.gdb.execute(script, bindings=bindings)
+        return resp.data[0]
+
+    def get_relationship_count(self, label=None):
+        """
+        Get the number of total relationships.
+        If "label" is provided, the number is calculated according the
+        the label of the element.
+        """
+        if label is not None:
+            labels = self._prep_labels(label)
+            script = "g.E().or(%s).count()" % labels
+        else:
+            script = """g.E().count()"""
+        resp = self.gdb.execute(script)
+        count = resp.data[0]
+        return count
+
+    # Quering
+    def query(self, *args, **kwargs):
+        # TODO: Define the requirements of the queries.
+        """
+        XXX
+        """
+        raise NotImplementedError("Method has to be implemented")
+
+    def nodes_query(self, *args, **kwargs):
+        # TODO: Define the requirements of the queries.
+        """
+        XXX
+        """
+        raise NotImplementedError("Method has to be implemented")
+
+    def relationships_query(self, *args, **kwargs):
+        # TODO: Define the requirements of the queries.
+        """
+        XXX
+        """
+        raise NotImplementedError("Method has to be implemented")
+
+    # Deleting the graph
+
+    def destroy(self):
+        """
+        Delete the entire graph and all the information related: nodes,
+        relationships, indices, etc.
+        """
+        raise NotImplementedError("Method has to be implemented")

--- a/sylva/engines/gdb/backends/tinkergraph.py
+++ b/sylva/engines/gdb/backends/tinkergraph.py
@@ -208,7 +208,6 @@ class GraphDatabase(BlueprintsGraphDatabase):
         if label is not None:
             labels = self._prep_labels(label)
             script = "g.V().or(%s).count()" % labels
-            print("SFsadfasdfsdfsad", script)
         else:
             script = """g.V().count()"""
         resp = self.gdb.execute(script)

--- a/sylva/engines/gdb/lookups/tinkergraph.py
+++ b/sylva/engines/gdb/lookups/tinkergraph.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from engines.gdb.lookups import BaseQ
+
+
+class Q(BaseQ):
+
+    STR_LOOKUPS = ("exact", "iexact", "contains", "icontains", "startswith",
+                   "istartswith", "endswith", "iendswith", "regex", "iregex")
+
+    def _get_lookup_and_match(self):
+        # Tinkergraph doesn't support text search lookups
+        if self.lookup in self.STR_LOOKUPS:
+            lookup = "eq"
+        elif self.lookup == "gt":
+            lookup = "gt"
+        elif self.lookup == "gte":
+            lookup = "gte"
+        elif self.lookup == "lt":
+            lookup = "lt"
+        elif self.lookup == "lte":
+            lookup = "lte"
+        elif self.lookup == "in":
+            lookup = "within"
+        elif self.lookup == "inrange":
+            lookup = "between"
+        # I don't think tinkergraph stores nulls
+        elif self.lookup == "isnull":
+            lookup = "eq"
+            if not self.match:
+                self.match = ""
+        elif self.lookup in ["eq", "equals"]:
+            lookup = "eq"
+        elif self.lookup in ["neq", "notequals"]:
+            lookup = "neq"
+        else:
+            lookup = self.lookup
+        return lookup, self.match
+
+    def get_query_objects(self, prefix=None, params=None):
+        if prefix is None:
+            prefix = ""
+        if params is None:
+            params = {}
+        if self._and is not None:
+            left_and = self._and[0].get_query_objects(params=params)
+            params.update(left_and[1])
+            right_and = self._and[1].get_query_objects(params=params)
+            params.update(right_and[1])
+            if self._and[0].is_valid() and self._and[1].is_valid():
+                query = "and({0}, {1})".format(left_and[0], right_and[0])
+            elif self._and[0].is_valid() and not self._and[1].is_valid():
+                query = "{0}".format(left_and[0])
+            elif not self._and[0].is_valid() and self._and[1].is_valid():
+                query = "{0}".format(right_and[0])
+            else:
+                query = u""
+        elif self._not is not None:
+            op_not = self._not.get_query_objects(params=params)
+            params.update(op_not[1])
+            # I'm not sure about this behavior
+            query = "negate({0})".format(op_not[0])
+        elif self._or is not None:
+            left_or = self._or[0].get_query_objects(params=params)
+            params.update(left_or[1])
+            right_or = self._or[1].get_query_objects(params=params)
+            params.update(right_or[1])
+            if self._or[0].is_valid() and self._or[1].is_valid():
+                query = "or({0},{1})".format(left_or[0], right_or[0])
+            elif self._or[0].is_valid() and not self._or[1].is_valid():
+                query = "{0}".format(left_or[0])
+            elif not self._or[0].is_valid() and self._or[1].is_valid():
+                query = "{0}".format(right_or[0])
+            else:
+                query = " "
+        else:
+            query = ""
+            lookup, match = self._get_lookup_and_match()
+        if self.property is not None:
+            key = "{0}p{1}".format(prefix, len(params))
+            params[key] = match
+            query_format = u"has('{0}', {1}({2}))"
+            query = query_format.format(self.property, lookup, key)
+        return query, params

--- a/sylva/engines/gdb/utils.py
+++ b/sylva/engines/gdb/utils.py
@@ -43,8 +43,10 @@ def get_connection_string(properties):
                                         path)
     elif user:
         uri = "%s://%s@%s:%s/%s/" % (schema, user, host, port, path)
-    else:
+    elif path:
         uri = "%s://%s:%s/%s/" % (schema, host, port, path)
+    else:
+        uri = "%s://%s:%s/" % (schema, host, port)
     query = properties.get("QUERY", None)
     if query:
         uri = "%s?%s" % (uri, query)


### PR DESCRIPTION
This is the same as #31, but targeting the `tinkerpop` branch.

This PR adds support for Tinkergraph, an in-memory reference implementation of a Tinkerpop3 enabled graph database system. This IS NOT meant to be a standalone backend for SylvaDB, instead it is a building block towards adding support for the new Titan when released, and will facilitate the use of any graphdb that uses the Gremlin Server for communication.

For connectivity it uses `gremlinrestclient`, a simple client based on requests. This client is pretty alpha, but it has a fairly comprehensive test suite.

This PR makes almost no changes to the existing code base. It adds a `tinkergraph.GraphDatabase` and `tinkergraph.Q` class to the existing implementations. These classes will be inherited from (and inevitably refactored) when adding support for Titan.

A few things to note:

 - Graph data is not persisted. Once the Server is stopped all node and edge data is lost.

 - Due to the lack of text searching capabilities, the Tinkergraph backend is not fully functional. For example, relationship creation must have exact text matches to work.

 - Because of this lack of functionality. The Tinkergraph backend is not run against the SylvaDB test suite, and does not work with reports, queries, and analytics (no dump implmented).

 - `tinkergraph.GraphDatabase` currently inherits from `blueprints.GraphDatabase` and therefore relies on the old pyblueprints API. In the future this will be upgraded to a more modern, lower level API.

In the near future, I plan to submit pull requests adding support for Titan, and Titan with Hadoop/Spark/Giraph graph analytics enabled. The Titan backend will eventually support all current SylvaDB apps.